### PR TITLE
Antigravity CLI in DevContainer using gVisor within custom Cloud Workstation image specified as DevContainer built by CICD-Foundation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,6 +110,14 @@ repos:
         pass_filenames: true
         require_serial: true
 
+      - id: markdown-link-checker
+        name: Markdown Link Checker (Go)
+        entry: bash -c 'cd skills/persona-swe/scripts && go run cmd/link_checker/main.go -- "${@/#/../../../}"' --
+        language: system
+        files: \.md$
+        pass_filenames: true
+        require_serial: true
+
       # --- SECTION: Skills & Personas ---
 
       - id: golangci-lint-persona

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Applications
 
 This directory hosts demo applications in kind of a mono-repository.
@@ -10,6 +26,7 @@ The directory structure is as follows:
 
 The following environment file is read by `/bin/` scripts when `envsubst`ing
 template files, starting services locally, or deploying to CloudRun:
+
 ```sh
 /apps/.env
 ```
@@ -21,7 +38,9 @@ You can overwrite variables for an application in these file(s):
 ```sh
 /apps/${APP_NAME}/envs/base/.env
 ```
+
 and/or further refine it for a specific environment:
+
 ```sh
 /apps/${APP_NAME}/envs/{ENV_NAME}/.env
 ```
@@ -31,6 +50,7 @@ and/or further refine it for a specific environment:
 ```sh
 /apps/${APP_NAME}/
 ```
+
 hosts an application or micro-service named `$APP_NAME`.
 The granularity of such application should be a (consumable) service in the scale of a pod,
 i.e., one or more containers running in one GKE Pod or Cloud Run instance.
@@ -38,9 +58,11 @@ i.e., one or more containers running in one GKE Pod or Cloud Run instance.
 #### skaffold.yaml
 
 Each such directory corresponds to a Skaffold project and must contain a
+
 ```sh
 /apps/${APP_NAME}/skaffold.yaml
 ```
+
 file that describes the project's dependencies, and/or how it
 can be built, tested, validated, and/or deployed
 (cf. [skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/)).
@@ -58,6 +80,7 @@ Typical environment names are `dev`, `test`, and `prod` for development, testing
 ##### Kustomize
 
 For Kubernetes manifests `kustomize` (part of `kubectl`) is leveraged and referenced as part of `skaffold` `profiles`:
+
 ```sh
 /apps/${APP_NAME}/envs/${ENV_NAME}/kustomization.yaml
 ```
@@ -65,6 +88,7 @@ For Kubernetes manifests `kustomize` (part of `kubectl`) is leveraged and refere
 ##### Template Files
 
 The `base` directory may contain a template of a manifest file for Knative services and/or jobs:
+
 ```sh
 /apps/${APP_NAME}/envs/base/knative.yaml.tmpl
 ```
@@ -78,13 +102,17 @@ The templating approach is adopted as CloudRun does not support namespaces
 (in contrast to GKE) and we use pre- and postfixes as part of the name.
 
 In addition to the global (`/apps/.env`) environment file (see above), application specific
+
 ```sh
 /apps/${APP_NAME}/envs/base/.env
 ```
- and environment specific files
+
+and environment specific files
+
 ```sh
 /apps/${APP_NAME}/envs/${ENV_NAME}/.env
 ```
+
 can be provided, e.g., to overwrite default and/or to define application
 or environment specific values.
 
@@ -94,6 +122,7 @@ or environment specific values.
 
 Code for the deployment of infrastructure - specifically required for the application
 (in contrast to predeployed and available shared resources such as Kubernetes clusters)
+
 - should be stored in
 
 ```sh

--- a/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/Dockerfile
+++ b/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest
+# Disable GCE check script during build to prevent hang
+ENV CLOUD_WORKSTATIONS_ENABLE_METADATA_CREDS_CHECK=true
+
+ARG GVISOR_VERSION=20260803.0
+ARG GVISOR_X86_64_SHA512=266ff0c74ba4faf137837c051e1d3c0a331bb1d3c152d791f349ef6680542d089b81f68e3c9f196a6fb82263909cfc583c39e98a0e058bb29c5ab752d9432805
+ARG GVISOR_AARCH64_SHA512=6548e3222a31b9f4029fd8ad4c78076ab336db9789f8fa0c68f3dbe410278b043e7dd18f283a44df248ac63b577082937777b727118af3388bec8c9cc9c931b8
+
+# Install gVisor (runsc)
+RUN apt-get update && apt-get install -y wget bzip2 && rm -rf /var/lib/apt/lists/* && \
+    ARCH=$(uname -m) && \
+    case "${ARCH}" in \
+        x86_64) SHA="${GVISOR_X86_64_SHA512}" ;; \
+        aarch64) SHA="${GVISOR_AARCH64_SHA512}" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    URL="https://storage.googleapis.com/gvisor/releases/release/${GVISOR_VERSION}/${ARCH}" && \
+    wget ${URL}/gvisor.tar.bz2 && \
+    echo "${SHA}  gvisor.tar.bz2" | sha512sum -c - && \
+    tar -xjf gvisor.tar.bz2 -C /usr/local/bin && \
+    rm -f gvisor.tar.bz2
+
+# Configure the pre-installed Docker daemon to use runsc
+RUN /usr/local/bin/runsc install

--- a/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/devcontainer-lock.json
+++ b/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/devcontainer-lock.json
@@ -14,9 +14,7 @@
       "version": "1.5.0",
       "resolved": "ghcr.io/devcontainers/features/terraform@sha256:bc9eaf21aaba050bace59f411c282cb58058535a48232c059e60c19f86caa8f5",
       "integrity": "sha256:bc9eaf21aaba050bace59f411c282cb58058535a48232c059e60c19f86caa8f5",
-      "dependsOn": [
-        "ghcr.io/devcontainers/features/github-cli:1"
-      ]
+      "dependsOn": ["ghcr.io/devcontainers/features/github-cli:1"]
     }
   }
 }

--- a/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/devcontainer.json
+++ b/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/devcontainer.json
@@ -1,12 +1,11 @@
 {
-  "name": "Code-OSS DevContainer (Node & Terraform)",
+  "name": "Code-OSS DevContainer (gVisor & Terraform)",
   "build": {
     "dockerfile": "Dockerfile",
     "context": "."
   },
   "features": {
     "ghcr.io/devcontainers/features/terraform:1": {},
-    "ghcr.io/devcontainers/features/node:2": {},
     "./features/devcontainer-cli-installer": {
       "version": "latest"
     }

--- a/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/features/devcontainer-cli-installer/devcontainer-feature.json
+++ b/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/features/devcontainer-cli-installer/devcontainer-feature.json
@@ -11,7 +11,5 @@
       "description": "Version of @devcontainers/cli to install"
     }
   },
-  "installAfter": [
-    "ghcr.io/devcontainers/features/node"
-  ]
+  "installAfter": ["ghcr.io/devcontainers/features/node"]
 }

--- a/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/features/devcontainer-cli-installer/install.sh
+++ b/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/.devcontainer/features/devcontainer-cli-installer/install.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 VERSION="${VERSION:-"latest"}"

--- a/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/skaffold.yaml
+++ b/apps/devcontainers/codeoss-devcontainer-gvisor-terraform/skaffold.yaml
@@ -15,9 +15,9 @@
 apiVersion: skaffold/v3
 kind: Config
 metadata:
-  name: devcontainer-codeoss-node-terraform
+  name: codeoss-devcontainer-gvisor-terraform
 build:
   artifacts:
-    - image: devcontainer-codeoss-node-terraform
+    - image: codeoss-devcontainer-gvisor-terraform
       custom:
         buildCommand: build_devcontainer $IMAGE

--- a/apps/devcontainers/codeoss-node-terraform/.devcontainer/Dockerfile
+++ b/apps/devcontainers/codeoss-node-terraform/.devcontainer/Dockerfile
@@ -1,3 +1,0 @@
-FROM us-central1-docker.pkg.dev/cloud-workstations-images/predefined/code-oss:latest
-# Disable GCE check script during build to prevent hang
-ENV CLOUD_WORKSTATIONS_ENABLE_METADATA_CREDS_CHECK=true

--- a/apps/devcontainers/gvisor-antigravity/.devcontainer/Dockerfile
+++ b/apps/devcontainers/gvisor-antigravity/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm
+
+ARG ANTIGRAVITY_CLI_VERSION=1.0.7
+ARG ANTIGRAVITY_CLI_SHA256=f5bb465edb938212eb0a185d68c420ff5b78f08c72de5a6d88dfefaf7af17074
+ARG ANTIGRAVITY_SDK_VERSION=0.1.3
+ARG ANTIGRAVITY_SDK_SHA256=74bd6f2c2e015de082cb39a6714cc344880657469532940d679451c779f8a660
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Install Antigravity CLI
+RUN curl -fsSL "https://github.com/google-antigravity/antigravity-cli/releases/download/${ANTIGRAVITY_CLI_VERSION}/agy_cli_linux_x64.tar.gz" -o cli.tar.gz && \
+    echo "${ANTIGRAVITY_CLI_SHA256}  cli.tar.gz" | sha256sum -c - && \
+    tar -xzf cli.tar.gz -C /usr/local/bin || tar -xzf cli.tar.gz -C /usr/local/bin && \
+    (mv /usr/local/bin/antigravity /usr/local/bin/antigravity-cli && ln -s /usr/local/bin/antigravity-cli /usr/local/bin/agy) || true && \
+    rm -f cli.tar.gz
+
+# Install Antigravity SDK
+RUN mkdir -p /opt/antigravity-sdk && \
+    curl -fsSL "https://github.com/google-antigravity/antigravity-sdk-python/archive/refs/tags/v${ANTIGRAVITY_SDK_VERSION}.tar.gz" -o sdk.tar.gz && \
+    echo "${ANTIGRAVITY_SDK_SHA256}  sdk.tar.gz" | sha256sum -c - && \
+    tar -xzf sdk.tar.gz -C /opt/antigravity-sdk --strip-components=1 && \
+    rm -f sdk.tar.gz
+
+ENV PYTHONPATH="${PYTHONPATH:-}:/opt/antigravity-sdk"

--- a/apps/devcontainers/gvisor-antigravity/.devcontainer/devcontainer.json
+++ b/apps/devcontainers/gvisor-antigravity/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "gVisor Antigravity DevContainer",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": ["--runtime=runsc"],
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python"]
+    }
+  }
+}

--- a/apps/devcontainers/gvisor-antigravity/README.md
+++ b/apps/devcontainers/gvisor-antigravity/README.md
@@ -1,0 +1,83 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# gVisor Antigravity DevContainer
+
+This guide explains how to start the `gvisor-antigravity` DevContainer using gVisor (`runsc`) and how to utilize the Antigravity CLI within it.
+
+## Prerequisites: Custom CWS Image
+
+To support this setup, you first need a Cloud Workstations (CWS) environment equipped with Development Containers and gVisor.
+
+The [`codeoss-devcontainer-gvisor-terraform`](../codeoss-devcontainer-gvisor-terraform) setup in `apps/devcontainers` can be utilized to build this custom CWS image.
+
+Once you have started a CWS instance running the custom image built by the `cicd-foundation`, you can verify the runtime environment. The gVisor binaries will be available at `/usr/local/bin/gvisor-bin/`, and you can confirm `runsc` is registered by checking Docker's configuration:
+
+```bash
+docker info | grep -i runtime
+```
+*(This command should list `runsc` among the available runtimes).*
+
+## Project Configuration
+
+To use the Antigravity DevContainer, set up your project's `.devcontainer/devcontainer.json` to specify `runsc` as the runtime and point to the custom image.
+
+Example configuration:
+
+```json
+{
+  "name": "devcontainer-gvisor-antigravity",
+  "image": "$REGION-docker.pkg.dev/$PROJECT_ID/cicd-foundation/devcontainer-gvisor-antigravity:latest",
+  "runArgs": [
+    "--runtime=runsc"
+  ],
+  "containerEnv": {
+    "AGY_ADC_AUTH": "true"
+  },
+  "mounts": [
+    "source=${env:HOME}/.config/antigravity,target=/home/vscode/.config/antigravity,type=bind,consistency=cached"
+  ]
+}
+```
+*(Note: Replace `$REGION` and `$PROJECT_ID` with your actual Google Cloud region and project ID).*
+
+## Authentication
+
+Before running commands, you must authenticate the Antigravity CLI. The recommended approach is to use Application Default Credentials (ADC) and set the `AGY_ADC_AUTH` environment variable (as configured in the `devcontainer.json` example above).
+
+1. Ensure ADC is configured in your environment.
+
+For detailed authentication instructions, see the official documentation:
+[Application Default Credentials (ADC) in Antigravity CLI](https://antigravity.google/docs/enterprise#application-default-credentials-adc-in-antigravity-cli).
+
+## Execution
+
+Before bringing up the DevContainer, ensure that the local directory for persisting authentication state exists:
+```bash
+mkdir -p ~/.config/antigravity
+```
+
+Once your CWS instance is running and the `.devcontainer.json` is configured, you can bring up the DevContainer and execute commands.
+
+Bring up the DevContainer:
+```bash
+devcontainer up
+```
+
+Execute an Antigravity (`agy`) command inside the gVisor-secured container:
+```bash
+devcontainer exec agy -p "Create a Hello World example in a fun programming language."
+```

--- a/apps/devcontainers/gvisor-antigravity/skaffold.yaml
+++ b/apps/devcontainers/gvisor-antigravity/skaffold.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: devcontainer-gvisor-antigravity
+build:
+  artifacts:
+    - image: devcontainer-gvisor-antigravity
+      context: .
+      docker:
+        dockerfile: .devcontainer/Dockerfile

--- a/apps/go-hello-world/envs/base/deployment.yaml
+++ b/apps/go-hello-world/envs/base/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ kind: Deployment
 metadata:
   name: go-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
-  replicas: 3                     # from-param: ${replicas}
+  replicas: 3 # from-param: ${replicas}
   template:
     metadata:
       labels:
-        commit-short-sha: ""      # from-param: ${commit-short-sha}
-        gcb-build-id: ""          # from-param: ${gcb-build-id}
+        commit-short-sha: "" # from-param: ${commit-short-sha}
+        gcb-build-id: "" # from-param: ${gcb-build-id}
     spec:
       containers:
         - name: go-hello-world

--- a/apps/go-hello-world/envs/base/gateway.yaml
+++ b/apps/go-hello-world/envs/base/gateway.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ kind: Gateway
 metadata:
   name: cicd-foundation-go
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
   # annotations:
   #  networking.gke.io/certmap: cicd-foundation-go
 spec:
@@ -32,12 +32,12 @@ spec:
   # - type: NamedAddress
   #  value: cicd-foundation-ipv6
   listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
-    allowedRoutes:
-      kinds:
-      - kind: HTTPRoute
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
   # - name: https
   #   protocol: HTTPS
   #   port: 443

--- a/apps/go-hello-world/envs/base/knative.yaml.tmpl
+++ b/apps/go-hello-world/envs/base/knative.yaml.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2024-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/go-hello-world/envs/base/kustomization.yaml
+++ b/apps/go-hello-world/envs/base/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ commonLabels:
   # gcb-build-id: ""            # from-param: ${gcb-build-id}
 
 resources:
-- namespace.yaml
-- deployment.yaml
-- service.yaml
-- gateway.yaml
-- route.yaml
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - gateway.yaml
+  - route.yaml
 
-namespace: go-hello-world       # from-param: ${namespace} # not supported yet
+namespace: go-hello-world # from-param: ${namespace} # not supported yet

--- a/apps/go-hello-world/envs/base/namespace.yaml
+++ b/apps/go-hello-world/envs/base/namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: go-hello-world            # from-param: ${namespace}
+  name: go-hello-world # from-param: ${namespace}
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}

--- a/apps/go-hello-world/envs/base/route.yaml
+++ b/apps/go-hello-world/envs/base/route.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: go-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   parentRefs:
-  - kind: Gateway
-    name: cicd-foundation-go
+    - kind: Gateway
+      name: cicd-foundation-go
   rules:
-  - backendRefs:
-    - name: go-hello-world
-      port: 80
+    - backendRefs:
+        - name: go-hello-world
+          port: 80

--- a/apps/go-hello-world/envs/base/service.yaml
+++ b/apps/go-hello-world/envs/base/service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ kind: Service
 metadata:
   name: go-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   type: ClusterIP
   selector:

--- a/apps/go-hello-world/envs/dev/kustomization.yaml
+++ b/apps/go-hello-world/envs/dev/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: dev
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/go-hello-world/envs/prod/kustomization.yaml
+++ b/apps/go-hello-world/envs/prod/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: prod
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/go-hello-world/envs/test/kustomization.yaml
+++ b/apps/go-hello-world/envs/test/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: test
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/go-hello-world/skaffold.yaml
+++ b/apps/go-hello-world/skaffold.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,48 +18,48 @@ metadata:
   name: go-hello-world
 build:
   artifacts:
-  - image: go-hello-world
-    context: src/go-hello-world
-    ko: {}
+    - image: go-hello-world
+      context: src/go-hello-world
+      ko: {}
 manifests:
   hooks:
     before:
-    - host:
-        command:
-        - "/bin/sh"
-        - "-c"
-        - "../../bin/generate.sh 2>/dev/null || true"
+      - host:
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "../../bin/generate.sh 2>/dev/null || true"
 deploy:
   statusCheckDeadlineSeconds: 3600 # deployment should stabilize within 60 minutes (NEG operations can take a little longer)
   tolerateFailuresUntilDeadline: true
   kubectl: {}
   # cloudrun: {}
 profiles:
-- name: dev
-  activation:
-    - command: dev
-  manifests:
-    # rawYaml:
-    #   - envs/dev/knative.yaml
-    kustomize:
-      paths:
-      - envs/dev
-  portForward:
-    - resourceType: Deployment
-      resourceName: go-hello-world
-      port: 8080
-      localPort: 8080
-- name: test
-  manifests:
-    # rawYaml:
-    #   - envs/test/knative.yaml
-    kustomize:
-      paths:
-      - envs/test
-- name: prod
-  manifests:
-    # rawYaml:
-    #   - envs/prod/knative.yaml
-    kustomize:
-      paths:
-      - envs/prod
+  - name: dev
+    activation:
+      - command: dev
+    manifests:
+      # rawYaml:
+      #   - envs/dev/knative.yaml
+      kustomize:
+        paths:
+          - envs/dev
+    portForward:
+      - resourceType: Deployment
+        resourceName: go-hello-world
+        port: 8080
+        localPort: 8080
+  - name: test
+    manifests:
+      # rawYaml:
+      #   - envs/test/knative.yaml
+      kustomize:
+        paths:
+          - envs/test
+  - name: prod
+    manifests:
+      # rawYaml:
+      #   - envs/prod/knative.yaml
+      kustomize:
+        paths:
+          - envs/prod

--- a/apps/go-hello-world/src/go-hello-world/main.go
+++ b/apps/go-hello-world/src/go-hello-world/main.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Google LLC
+// Copyright 2023-2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/java-hello-world/envs/base/deployment.yaml
+++ b/apps/java-hello-world/envs/base/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ kind: Deployment
 metadata:
   name: java-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
-  replicas: 3                     # from-param: ${replicas}
+  replicas: 3 # from-param: ${replicas}
   template:
     metadata:
       labels:
-        commit-short-sha: ""      # from-param: ${commit-short-sha}
-        gcb-build-id: ""          # from-param: ${gcb-build-id}
+        commit-short-sha: "" # from-param: ${commit-short-sha}
+        gcb-build-id: "" # from-param: ${gcb-build-id}
     spec:
       containers:
         - name: java-hello-world

--- a/apps/java-hello-world/envs/base/gateway.yaml
+++ b/apps/java-hello-world/envs/base/gateway.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +17,14 @@ kind: Gateway
 metadata:
   name: cicd-foundation-java
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   gatewayClassName: gke-l7-rilb
   listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
-    allowedRoutes:
-      kinds:
-      - kind: HTTPRoute
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute

--- a/apps/java-hello-world/envs/base/knative.yaml.tmpl
+++ b/apps/java-hello-world/envs/base/knative.yaml.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2024-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/java-hello-world/envs/base/kustomization.yaml
+++ b/apps/java-hello-world/envs/base/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ commonLabels:
   # gcb-build-id: ""        # from-param: ${gcb-build-id}
 
 resources:
-- namespace.yaml
-- deployment.yaml
-- service.yaml
-- gateway.yaml
-- route.yaml
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - gateway.yaml
+  - route.yaml
 
 namespace: java-hello-world # from-param: ${namespace} # not supported yet

--- a/apps/java-hello-world/envs/base/namespace.yaml
+++ b/apps/java-hello-world/envs/base/namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: java-hello-world          # from-param: ${namespace}
+  name: java-hello-world # from-param: ${namespace}
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}

--- a/apps/java-hello-world/envs/base/route.yaml
+++ b/apps/java-hello-world/envs/base/route.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: java-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   parentRefs:
-  - kind: Gateway
-    name: cicd-foundation-java
+    - kind: Gateway
+      name: cicd-foundation-java
   rules:
-  - backendRefs:
-    - name: java-hello-world
-      port: 80
+    - backendRefs:
+        - name: java-hello-world
+          port: 80

--- a/apps/java-hello-world/envs/base/service.yaml
+++ b/apps/java-hello-world/envs/base/service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ kind: Service
 metadata:
   name: java-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   type: ClusterIP
   selector:

--- a/apps/java-hello-world/envs/dev/kustomization.yaml
+++ b/apps/java-hello-world/envs/dev/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: dev
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/java-hello-world/envs/prod/kustomization.yaml
+++ b/apps/java-hello-world/envs/prod/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: prod
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/java-hello-world/envs/test/kustomization.yaml
+++ b/apps/java-hello-world/envs/test/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: test
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/java-hello-world/skaffold.yaml
+++ b/apps/java-hello-world/skaffold.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,52 +18,52 @@ metadata:
   name: java-hello-world
 build:
   artifacts:
-  - image: java-hello-world
-    context: src/java-hello-world
-    #jib: {}
-    buildpacks:
-      env:
-      # cf. https://cloud.google.com/docs/buildpacks/java#specify_a_java_version
-      - GOOGLE_RUNTIME_VERSION=17
+    - image: java-hello-world
+      context: src/java-hello-world
+      #jib: {}
+      buildpacks:
+        env:
+          # cf. https://cloud.google.com/docs/buildpacks/java#specify_a_java_version
+          - GOOGLE_RUNTIME_VERSION=17
 manifests:
   hooks:
     before:
-    - host:
-        command:
-        - "/bin/sh"
-        - "-c"
-        - "../../bin/generate.sh 2>/dev/null || true"
+      - host:
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "../../bin/generate.sh 2>/dev/null || true"
 deploy:
   statusCheckDeadlineSeconds: 3600 # deployment should stabilize within 60 minutes (NEG operations can take a little longer)
   tolerateFailuresUntilDeadline: true
   kubectl: {}
   # cloudrun: {}
 profiles:
-- name: dev
-  activation:
-    - command: dev
-  manifests:
-    # rawYaml:
-    #   - envs/dev/knative.yaml
-    kustomize:
-      paths:
-      - envs/dev
-  portForward:
-    - resourceType: Deployment
-      resourceName: java-hello-world
-      port: 8080
-      localPort: 8080
-- name: test
-  manifests:
-    # rawYaml:
-    #   - envs/test/knative.yaml
-    kustomize:
-      paths:
-      - envs/test
-- name: prod
-  manifests:
-    # rawYaml:
-    #   - envs/prod/knative.yaml
-    kustomize:
-      paths:
-      - envs/prod
+  - name: dev
+    activation:
+      - command: dev
+    manifests:
+      # rawYaml:
+      #   - envs/dev/knative.yaml
+      kustomize:
+        paths:
+          - envs/dev
+    portForward:
+      - resourceType: Deployment
+        resourceName: java-hello-world
+        port: 8080
+        localPort: 8080
+  - name: test
+    manifests:
+      # rawYaml:
+      #   - envs/test/knative.yaml
+      kustomize:
+        paths:
+          - envs/test
+  - name: prod
+    manifests:
+      # rawYaml:
+      #   - envs/prod/knative.yaml
+      kustomize:
+        paths:
+          - envs/prod

--- a/apps/java-hello-world/src/java-hello-world/pom.xml
+++ b/apps/java-hello-world/src/java-hello-world/pom.xml
@@ -1,3 +1,19 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/apps/node-hello-world/envs/base/deployment.yaml
+++ b/apps/node-hello-world/envs/base/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ kind: Deployment
 metadata:
   name: node-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
-  replicas: 3                     # from-param: ${replicas}
+  replicas: 3 # from-param: ${replicas}
   template:
     metadata:
       labels:
-        commit-short-sha: ""      # from-param: ${commit-short-sha}
-        gcb-build-id: ""          # from-param: ${gcb-build-id}
+        commit-short-sha: "" # from-param: ${commit-short-sha}
+        gcb-build-id: "" # from-param: ${gcb-build-id}
     spec:
       containers:
         - name: node-hello-world

--- a/apps/node-hello-world/envs/base/gateway.yaml
+++ b/apps/node-hello-world/envs/base/gateway.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +17,14 @@ kind: Gateway
 metadata:
   name: cicd-foundation-node
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   gatewayClassName: gke-l7-rilb
   listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
-    allowedRoutes:
-      kinds:
-      - kind: HTTPRoute
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute

--- a/apps/node-hello-world/envs/base/knative.yaml.tmpl
+++ b/apps/node-hello-world/envs/base/knative.yaml.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2024-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/node-hello-world/envs/base/kustomization.yaml
+++ b/apps/node-hello-world/envs/base/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ commonLabels:
   # gcb-build-id: ""        # from-param: ${gcb-build-id}
 
 resources:
-- namespace.yaml
-- deployment.yaml
-- service.yaml
-- gateway.yaml
-- route.yaml
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - gateway.yaml
+  - route.yaml
 
 namespace: node-hello-world # from-param: ${namespace} # not supported yet

--- a/apps/node-hello-world/envs/base/namespace.yaml
+++ b/apps/node-hello-world/envs/base/namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: node-hello-world          # from-param: ${namespace}
+  name: node-hello-world # from-param: ${namespace}
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}

--- a/apps/node-hello-world/envs/base/route.yaml
+++ b/apps/node-hello-world/envs/base/route.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: node-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   parentRefs:
-  - kind: Gateway
-    name: cicd-foundation-node
+    - kind: Gateway
+      name: cicd-foundation-node
   rules:
-  - backendRefs:
-    - name: node-hello-world
-      port: 80
+    - backendRefs:
+        - name: node-hello-world
+          port: 80

--- a/apps/node-hello-world/envs/base/service.yaml
+++ b/apps/node-hello-world/envs/base/service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ kind: Service
 metadata:
   name: node-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   type: ClusterIP
   selector:

--- a/apps/node-hello-world/envs/dev/kustomization.yaml
+++ b/apps/node-hello-world/envs/dev/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: dev
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/node-hello-world/envs/prod/kustomization.yaml
+++ b/apps/node-hello-world/envs/prod/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: prod
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/node-hello-world/envs/test/kustomization.yaml
+++ b/apps/node-hello-world/envs/test/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: test
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/node-hello-world/skaffold.yaml
+++ b/apps/node-hello-world/skaffold.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,48 +18,48 @@ metadata:
   name: node-hello-world
 build:
   artifacts:
-  - image: node-hello-world
-    context: src/node-hello-world
-    buildpacks: {}
+    - image: node-hello-world
+      context: src/node-hello-world
+      buildpacks: {}
 manifests:
   hooks:
     before:
-    - host:
-        command:
-        - "/bin/sh"
-        - "-c"
-        - "../../bin/generate.sh 2>/dev/null || true"
+      - host:
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "../../bin/generate.sh 2>/dev/null || true"
 deploy:
   statusCheckDeadlineSeconds: 3600 # deployment should stabilize within 60 minutes (NEG operations can take a little longer)
   tolerateFailuresUntilDeadline: true
   kubectl: {}
   # cloudrun: {}
 profiles:
-- name: dev
-  activation:
-    - command: dev
-  manifests:
-    # rawYaml:
-    #   - envs/dev/knative.yaml
-    kustomize:
-      paths:
-      - envs/dev
-  portForward:
-    - resourceType: Deployment
-      resourceName: node-hello-world
-      port: 8080
-      localPort: 8080
-- name: test
-  manifests:
-    # rawYaml:
-    #   - envs/test/knative.yaml
-    kustomize:
-      paths:
-      - envs/test
-- name: prod
-  manifests:
-    # rawYaml:
-    #   - envs/prod/knative.yaml
-    kustomize:
-      paths:
-      - envs/prod
+  - name: dev
+    activation:
+      - command: dev
+    manifests:
+      # rawYaml:
+      #   - envs/dev/knative.yaml
+      kustomize:
+        paths:
+          - envs/dev
+    portForward:
+      - resourceType: Deployment
+        resourceName: node-hello-world
+        port: 8080
+        localPort: 8080
+  - name: test
+    manifests:
+      # rawYaml:
+      #   - envs/test/knative.yaml
+      kustomize:
+        paths:
+          - envs/test
+  - name: prod
+    manifests:
+      # rawYaml:
+      #   - envs/prod/knative.yaml
+      kustomize:
+        paths:
+          - envs/prod

--- a/apps/node-hello-world/src/node-hello-world/index.js
+++ b/apps/node-hello-world/src/node-hello-world/index.js
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Google LLC
+// Copyright 2023-2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-'use strict';
+"use strict";
 
-const port = 8080
-const name = process.env.NAME || 'World';
+const port = 8080;
+const name = process.env.NAME || "World";
 
-const express = require('express')
-const app = express()
+const express = require("express");
+const app = express();
 
-app.use(express.static('public'));
-app.get('/', (req, res) => res.send(`Hello ${name} from NodeJS!`))
+app.use(express.static("public"));
+app.get("/", (req, res) => res.send(`Hello ${name} from NodeJS!`));
 
-app.listen(port, () => console.log(`Listening on Port ${port}.`))
+app.listen(port, () => console.log(`Listening on Port ${port}.`));

--- a/apps/node-hello-world/src/node-hello-world/public/hello.html
+++ b/apps/node-hello-world/src/node-hello-world/public/hello.html
@@ -1,10 +1,26 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Hello World (NodeJS)</title>
-</head>
-<body>
-  <h1>Hello World!</h1>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello World (NodeJS)</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+  </body>
 </html>

--- a/apps/python-hello-world/envs/base/deployment.yaml
+++ b/apps/python-hello-world/envs/base/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ kind: Deployment
 metadata:
   name: python-hello-world
   labels:
-    commit-short-sha: ""          # from-param: ${commit-short-sha}
-    gcb-build-id: ""              # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
-  replicas: 3                     # from-param: ${replicas}
+  replicas: 3 # from-param: ${replicas}
   template:
     metadata:
       labels:
-        commit-short-sha: ""      # from-param: ${commit-short-sha}
-        gcb-build-id: ""          # from-param: ${gcb-build-id}
+        commit-short-sha: "" # from-param: ${commit-short-sha}
+        gcb-build-id: "" # from-param: ${gcb-build-id}
     spec:
       containers:
         - name: python-hello-world

--- a/apps/python-hello-world/envs/base/gateway.yaml
+++ b/apps/python-hello-world/envs/base/gateway.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ metadata:
 spec:
   gatewayClassName: gke-l7-rilb
   listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
-    allowedRoutes:
-      kinds:
-      - kind: HTTPRoute
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute

--- a/apps/python-hello-world/envs/base/knative.yaml.tmpl
+++ b/apps/python-hello-world/envs/base/knative.yaml.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2024-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/python-hello-world/envs/base/kustomization.yaml
+++ b/apps/python-hello-world/envs/base/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ commonLabels:
   # gcb-build-id: ""          # from-param: ${gcb-build-id}
 
 resources:
-- namespace.yaml
-- deployment.yaml
-- service.yaml
-- gateway.yaml
-- route.yaml
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - gateway.yaml
+  - route.yaml
 
 namespace: python-hello-world # from-param: ${namespace} # not supported yet

--- a/apps/python-hello-world/envs/base/namespace.yaml
+++ b/apps/python-hello-world/envs/base/namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: python-hello-world  # from-param: ${namespace}
+  name: python-hello-world # from-param: ${namespace}

--- a/apps/python-hello-world/envs/base/route.yaml
+++ b/apps/python-hello-world/envs/base/route.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ metadata:
   name: python-hello-world
 spec:
   parentRefs:
-  - kind: Gateway
-    name: cicd-foundation-python
+    - kind: Gateway
+      name: cicd-foundation-python
   rules:
-  - backendRefs:
-    - name: python-hello-world
-      port: 80
+    - backendRefs:
+        - name: python-hello-world
+          port: 80

--- a/apps/python-hello-world/envs/base/service.yaml
+++ b/apps/python-hello-world/envs/base/service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ kind: Service
 metadata:
   name: python-hello-world
   labels:
-    commit-short-sha: ""        # from-param: ${commit-short-sha}
-    gcb-build-id: ""            # from-param: ${gcb-build-id}
+    commit-short-sha: "" # from-param: ${commit-short-sha}
+    gcb-build-id: "" # from-param: ${gcb-build-id}
 spec:
   type: ClusterIP
   selector:

--- a/apps/python-hello-world/envs/dev/kustomization.yaml
+++ b/apps/python-hello-world/envs/dev/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: dev
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/python-hello-world/envs/prod/kustomization.yaml
+++ b/apps/python-hello-world/envs/prod/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: prod
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/python-hello-world/envs/test/kustomization.yaml
+++ b/apps/python-hello-world/envs/test/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,4 +19,4 @@ commonLabels:
   environment: test
 
 resources:
-- ./../base
+  - ./../base

--- a/apps/python-hello-world/skaffold.yaml
+++ b/apps/python-hello-world/skaffold.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,48 +18,48 @@ metadata:
   name: python-hello-world
 build:
   artifacts:
-  - image: python-hello-world
-    context: src/python-hello-world
-    buildpacks: {}
+    - image: python-hello-world
+      context: src/python-hello-world
+      buildpacks: {}
 manifests:
   hooks:
     before:
-    - host:
-        command:
-        - "/bin/sh"
-        - "-c"
-        - "../../bin/generate.sh 2>/dev/null || true"
+      - host:
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "../../bin/generate.sh 2>/dev/null || true"
 deploy:
   statusCheckDeadlineSeconds: 3600 # deployment should stabilize within 60 minutes (NEG operations can take a little longer)
   tolerateFailuresUntilDeadline: true
   kubectl: {}
   # cloudrun: {}
 profiles:
-- name: dev
-  activation:
-    - command: dev
-  manifests:
-    # rawYaml:
-    #   - envs/dev/knative.yaml
-    kustomize:
-      paths:
-      - envs/dev
-  portForward:
-    - resourceType: Deployment
-      resourceName: python-hello-world
-      port: 8080
-      localPort: 8080
-- name: test
-  manifests:
-    # rawYaml:
-    #   - envs/test/knative.yaml
-    kustomize:
-      paths:
-      - envs/test
-- name: prod
-  manifests:
-    # rawYaml:
-    #   - envs/prod/knative.yaml
-    kustomize:
-      paths:
-      - envs/prod
+  - name: dev
+    activation:
+      - command: dev
+    manifests:
+      # rawYaml:
+      #   - envs/dev/knative.yaml
+      kustomize:
+        paths:
+          - envs/dev
+    portForward:
+      - resourceType: Deployment
+        resourceName: python-hello-world
+        port: 8080
+        localPort: 8080
+  - name: test
+    manifests:
+      # rawYaml:
+      #   - envs/test/knative.yaml
+      kustomize:
+        paths:
+          - envs/test
+  - name: prod
+    manifests:
+      # rawYaml:
+      #   - envs/prod/knative.yaml
+      kustomize:
+        paths:
+          - envs/prod

--- a/apps/python-hello-world/src/python-hello-world/README.md
+++ b/apps/python-hello-world/src/python-hello-world/README.md
@@ -1,2 +1,18 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 A Hello World application in Python.
 A "NAME" environment variable can be used for customizing the output.

--- a/apps/python-hello-world/src/python-hello-world/hello_world/__init__.py
+++ b/apps/python-hello-world/src/python-hello-world/hello_world/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/apps/python-hello-world/src/python-hello-world/hello_world/app.py
+++ b/apps/python-hello-world/src/python-hello-world/hello_world/app.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 """A Hello World application."""
 
 import os
+
 from flask import Flask
 
 app = Flask(__name__)
@@ -22,10 +23,10 @@ app = Flask(__name__)
 
 @app.route("/")
 def index() -> str:
-  """returns a hello world message
+    """returns a hello world message
 
-  Returns:
-      str: a hello world message
-  """
-  name = os.environ.get("NAME", "World")
-  return "Hello " + name + " from Python!"
+    Returns:
+        str: a hello world message
+    """
+    name = os.environ.get("NAME", "World")
+    return "Hello " + name + " from Python!"

--- a/apps/python-hello-world/src/python-hello-world/tests/__init__.py
+++ b/apps/python-hello-world/src/python-hello-world/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/apps/workstations/android-studio-for-platform/Dockerfile
+++ b/apps/workstations/android-studio-for-platform/Dockerfile
@@ -27,7 +27,7 @@ ARG BUILDER_PKGS="\
   equivs \
   git \
   golang"
-ARG LIBTINFO5_VERSION="6.3-2ubuntu0.1_amd64"
+ARG LIBTINFO5_VERSION="6.3-2ubuntu0.2_amd64"
 ARG RETRY_ATTEMPTS=3
 ARG RETRY_DELAY=5
 ARG CUTTLEFISH_RETRY_ATTEMPTS=8
@@ -77,6 +77,8 @@ ARG RETRY_ATTEMPTS
 ARG RETRY_DELAY
 ARG CUTTLEFISH_RETRY_ATTEMPTS
 ARG GCP_REGION
+
+SHELL ["/bin/bash", "-c"]
 
 # Use common.sh retry helper from base image
 COPY --from=base-provider /google/scripts/common.sh /google/scripts/common.sh

--- a/apps/workstations/android-studio-for-platform/README.md
+++ b/apps/workstations/android-studio-for-platform/README.md
@@ -54,7 +54,6 @@ This image supports and propagates all base arguments, including:
 - **[Design Document](./docs/design.md)**: Deep-dive into the layering, hook-based integration logic, and Cuttlefish setup.
 - **[Technical Requirements](./docs/requirements.md)**: Functional and non-functional requirements for the ASfP layer.
 - **[System Overview & Design](../../../docs/workstations/design.md)**: High-level map of the entire Cloud Workstations Custom Image blueprint stack.
-- **[Software Bill of Materials](./docs/software_bill_of_materials.md)**: Details on the packages and versions included in this image.
 - **[Base Blueprint Docs](../gnome/docs/design.md)**: Deep-dives into the underlying systemd orchestrations and networking handover logic.
 
 ## Getting Started

--- a/apps/workstations/antigravity2/AGENTS.md
+++ b/apps/workstations/antigravity2/AGENTS.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # AI Agent Instructions: Antigravity 2.0 Layer
 
 Specific mandates for the Antigravity 2.0 application environment.

--- a/apps/workstations/antigravity2/README.md
+++ b/apps/workstations/antigravity2/README.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Antigravity 2.0 Custom Image for Cloud Workstations
 
 This image layers the **Antigravity 2.0** application onto the [GNOME Workstation Blueprint](../gnome/README.md).
@@ -10,8 +26,8 @@ Antigravity 2.0 provides a next-generation development experience with advanced 
 
 The following build arguments can be used to customize the image:
 
-| Argument | Default | Description |
-| :--- | :--- | :--- |
+| Argument              | Default | Description                            |
+| :-------------------- | :------ | :------------------------------------- |
 | `ANTIGRAVITY_VERSION` | `1.0.7` | The version of Antigravity to install. |
 
 ## Documentation

--- a/apps/workstations/antigravity2/assets/build-hooks.d/01_install_antigravity2.sh
+++ b/apps/workstations/antigravity2/assets/build-hooks.d/01_install_antigravity2.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 source /google/scripts/fetch_assets.sh
 
 # Define variables
+# shellcheck disable=SC2269
 ANTIGRAVITY2_VERSION="${ANTIGRAVITY2_VERSION}"
+# shellcheck disable=SC2269
 ANTIGRAVITY2_SHA256="${ANTIGRAVITY2_SHA256}"
+# shellcheck disable=SC2269
 CURL_OPTS="${CURL_OPTS}"
 
 # Construct the download URL
@@ -21,5 +39,3 @@ download_and_validate "${DOWNLOAD_URL}" "${ANTIGRAVITY2_SHA256}" "${TARBALL_NAME
 mkdir -p "${EXTRACT_DIR}"
 tar -xzf "${TARBALL_NAME}" -C "${EXTRACT_DIR}"
 rm "${TARBALL_NAME}"
-
-

--- a/apps/workstations/antigravity2/assets/usr/share/applications/antigravity.desktop
+++ b/apps/workstations/antigravity2/assets/usr/share/applications/antigravity.desktop
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [Desktop Entry]
 Name=Antigravity 2.0
 Comment=Antigravity 2.0

--- a/apps/workstations/gnome/README.md
+++ b/apps/workstations/gnome/README.md
@@ -40,9 +40,9 @@ The core environment providing the desktop experience, systemd orchestration, an
 
 A cinematic loading interface that intercepts early traffic and provides technical telemetry.
 
-- 👉 **[UX Standards](../../preflight/docs/ux_standards.md)**
-- 👉 **[Language Priorities](../../preflight/docs/language_priorities.md)**
-- 👉 **[Design Document](../../preflight/docs/design.md)**
+- 👉 **[UX Standards](../preflight/docs/design.md#33-cinematic-ux-principles)**
+- 👉 **[Language Priorities](../preflight/docs/requirements.md#42-internationalization-i18n)**
+- 👉 **[Design Document](../preflight/docs/design.md)**
 
 ## 🛠️ Global Tooling
 

--- a/apps/workstations/gnome/assets/etc/profile.d/google-bin.sh
+++ b/apps/workstations/gnome/assets/etc/profile.d/google-bin.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Add /google/bin to PATH for interactive shells.
 if [[ ":$PATH:" != *":/google/bin:"* ]]; then
   PATH="${PATH}:/google/bin"

--- a/apps/workstations/gnome/assets/google/scripts/fetch_assets.sh
+++ b/apps/workstations/gnome/assets/google/scripts/fetch_assets.sh
@@ -164,4 +164,3 @@ main() {
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi
-

--- a/apps/workstations/gnome/docs/README.md
+++ b/apps/workstations/gnome/docs/README.md
@@ -44,8 +44,8 @@ To ensure consistency and compatibility across the project, adhere to the follow
 | :------------------------------------------------------------- | :---------------------------------------------------------------- |
 | [design.md](design.md)                                         | Core architecture, Systemd orchestration, and developer patterns. |
 | [requirements.md](requirements.md)                             | Functional and non-functional requirements for the GNOME layer.   |
-| [admin_guide.md](../../docs/iac/admin_guide.md)                | Infrastructure and build pipeline details.                        |
-| [ux_standards.md](../../preflight/docs/ux_standards.md)        | Accessibility and design language for the desktop.                |
+| [admin_guide.md](../../../../docs/iac/admin_guide.md)                | Infrastructure and build pipeline details.                        |
+| [preflight/design.md (UX)](../../preflight/docs/design.md#33-cinematic-ux-principles) | Accessibility and design language for the desktop. |
 | [software_bill_of_materials.md](software_bill_of_materials.md) | Tracking of bundled OSS components and licenses.                  |
 | [environment_variables.md](environment_variables.md)           | Runtime and build-time configuration reference.                   |
 | [style_guides/](../../../../docs/style_guides/)                | Language-specific coding and configuration standards.             |

--- a/apps/workstations/preflight-web/public/locales/en.json
+++ b/apps/workstations/preflight-web/public/locales/en.json
@@ -83,7 +83,7 @@
   "software_description": "This blueprint provides a high-performance, containerized GNOME desktop environment for Google Cloud Workstations, featuring automated lifecycle management and immersive status monitoring.",
   "status_message": "You will be redirected when the connection is ready.",
   "status_message_manual": "You will be notified once the connection is ready.",
-  "status_message_permanent_failure": "Startup is taking longer than expected. Continuing with exponential backoff...",
+  "status_message_permanent_failure": "Workstation failed to start within the maximum time limit. Please contact support or try restarting the session.",
   "status_message_ready": "Connection is ready. Click or press Enter to continue.",
   "status_message_timeout": "Startup is taking longer than expected. Continuing with exponential backoff...",
   "status_ready": "READY",

--- a/apps/workstations/preflight/AGENTS.md
+++ b/apps/workstations/preflight/AGENTS.md
@@ -33,7 +33,7 @@ These mandates apply specifically to the Preflight layer (`examples/preflight/`)
 ## 3. Global Foundation Skills
 
 Refer to the root instructions for global tools:
-👉 **[Foundation Skills](../../AGENTS.md#3-global-agent-skills-foundation)**
+👉 **[Foundation Skills](../../../AGENTS.md#3-global-agent-skills-foundation)**
 
 ## 4. Mandatory Testing
 

--- a/docs/devcontainers/design.md
+++ b/docs/devcontainers/design.md
@@ -32,7 +32,7 @@ graph TD
     Terraform[Terraform Config] -->|defines| CustomImage[cws_custom_images]
     CustomImage -->|triggers build| CloudBuild[Cloud Build Trigger]
     CloudBuild -->|runs| Skaffold[Skaffold Build]
-    Skaffold -->|auto-detects devcontainer| DevContainerCLI[@devcontainers/cli]
+    Skaffold -->|auto-detects devcontainer| DevContainerCLI["@devcontainers/cli"]
     DevContainerCLI -->|builds & pushes| AR[Artifact Registry]
     CWSConfig[CWS Config] -->|references image key| AR
 ```

--- a/docs/hackathon_guide.md
+++ b/docs/hackathon_guide.md
@@ -128,7 +128,7 @@ cws_configs = {
 
 For detailed instructions on running the Terraform commands, monitoring the build, and connecting via SSH, refer to the deployment guide:
 
-👉 **[Infrastructure & Deployment Guide](../iac/admin_guide.md)**
+👉 **[Infrastructure & Deployment Guide](iac/admin_guide.md)**
 
 ## 3. Governance & Constraints
 

--- a/exercises/E0_preparations/01_workstation/README.md
+++ b/exercises/E0_preparations/01_workstation/README.md
@@ -2,12 +2,12 @@
 
 ## Your Cloud Workstation
 
-Using the [Infra-as-Code](../../infra/README.md) for the [simplified](../../infra/simplified/) architecture, your Cloud Workstation has been provisioned, e.g., by a central-IT team. You can directly jump to "Access your Cloud Workstation section".  
+Using the [Infra-as-Code](../../../infra/README.md) for the [simplified](../../../infra/simplified/) architecture, your Cloud Workstation has been provisioned, e.g., by a central-IT team. You can directly jump to "Access your Cloud Workstation section".  
 If you are interested on how to create a workstation, you can have a look at below folded section.
 
 <details>
 <summary>Create your Cloud Workstation</summary>
-If your Google Identity has been granted the [roles/workstations.workstationCreator](https://cloud.google.com/iam/docs/understanding-roles#workstations.workstationCreator) role in the project, you can create your workstation and use the provisioned [Workstation Cluster](../../infra/simplified/hub/workstations.tf#L15) and [Workstation Config](../../infra/simplified/hub/workstations.tf#L24).  
+If your Google Identity has been granted the [roles/workstations.workstationCreator](https://cloud.google.com/iam/docs/understanding-roles#workstations.workstationCreator) role in the project, you can create your workstation and use the provisioned [Workstation Cluster](../../../infra/simplified/hub/workstations.tf#L15) and [Workstation Config](../../../infra/simplified/hub/workstations.tf#L24).  
 
 <br/>
 Create your workstation with either of the methods below (gcloud, Terraform, Google Cloud Console):  

--- a/exercises/E2_skaffold-dev/README.md
+++ b/exercises/E2_skaffold-dev/README.md
@@ -22,7 +22,7 @@ gcloud auth configure-docker $REGION-docker.pkg.dev
 <details>
 <summary>Skaffold</summary>
 
-⚠️ Did you [set the default container repository for Skaffold](../04_skaffold/)?
+⚠️ Did you [set the default container repository for Skaffold](../E0_preparations/05_skaffold/)?
 
 ```sh
 skaffold dev
@@ -31,7 +31,7 @@ skaffold dev
 
 ### Validating the deployment
 
-⚠️ In case you are using [Remote-SSH](../01_workstation/README.md#remote-ssh) a `Preview Link` is provided that you can open.
+⚠️ In case you are using [Remote-SSH](../E0_preparations/01_workstation/README.md#remote-ssh) a `Preview Link` is provided that you can open.
 
 <details>
 <summary>HTTP Request</summary>
@@ -68,5 +68,5 @@ Note: By default an **internal** Application Load Balancer is used that can only
 
 You may want to customize the value of the `NAME` environment variable as defined in the [`deployment.yaml`](../../apps/go-hello-world/envs/base/deployment.yaml#L46).
 
-Also you can modify [`main.go`](../../apps/go-hello-world/src/main.go#L55), e.g., by uppercassing `Hello` or translating it to another language.
+Also you can modify [`main.go`](../../apps/go-hello-world/src/go-hello-world/main.go#L55), e.g., by uppercassing `Hello` or translating it to another language.
 </details>

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Infrastructure Setup
 
 - For the hands-on workshop use the [simplified](simplified/) folder.
@@ -22,7 +38,7 @@ In the hands-on workshop the participants will be able to check out and work wit
 ### Cloud Storage Bucket
 
 This is for storing the Terraform state file.  
-It is recommended to create / use a bucket in a (central) "seed" project that is used for infrastructure automation.  
+It is recommended to create / use a bucket in a (central) "seed" project that is used for infrastructure automation.
 
 👉 Change `YOUR_BUCKET` in `backend.tf.example` and rename to `backend.tf`.
 
@@ -73,6 +89,7 @@ kritis_signer_image = "gcr.io/…/kritis-signer@sha256:…"
 ```
 
 Re-run terraform:
+
 ```
 terraform apply
 ```
@@ -80,7 +97,6 @@ terraform apply
 #### References 🔗
 
 - [Set up the Kritis Signer custom builder](https://cloud.google.com/binary-authorization/docs/creating-attestations-kritis#set_up_the_kritis_signer_custom_builder)
-
 
 ## Clean-up
 

--- a/infra/blueprints/workstations/README.md
+++ b/infra/blueprints/workstations/README.md
@@ -1,3 +1,19 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Cloud Workstations Terraform Blueprint
 
 This blueprint contains Terraform configuration for deploying and managing
@@ -10,29 +26,29 @@ consistent development environments tailored to your team's needs.
 
 ## Features
 
-*   Deploys Cloud Workstations Cluster, Config, and Workstation resources.
-*   Supports launching workstations from Google-provided
-    [preconfigured base images](https://cloud.google.com/workstations/docs/preconfigured-base-images)
-    or your own
-    [custom container images](https://cloud.google.com/workstations/docs/customize-container-images).
-*   Configurable machine types, disk types/sizes, regions, and network settings.
-*   Option to set IAM policies for workstations.
+- Deploys Cloud Workstations Cluster, Config, and Workstation resources.
+- Supports launching workstations from Google-provided
+  [preconfigured base images](https://cloud.google.com/workstations/docs/preconfigured-base-images)
+  or your own
+  [custom container images](https://cloud.google.com/workstations/docs/customize-container-images).
+- Configurable machine types, disk types/sizes, regions, and network settings.
+- Option to set IAM policies for workstations.
 
 ### Resources Provisioned by this Blueprint
 
 This blueprint provisions the following key Cloud Workstations resources:
 
-*   **Workstation Cluster**: Provides the management layer and VPC connection
-    for workstation configurations within a specific region.
-*   **Workstation Config**: Defines the template for workstations hosted in the
-    cluster. This includes settings like:
-    *   Machine type, disk type, and size.
-    *   Idle timeout and running timeout.
-    *   The container image to use (either a preconfigured Google image or a
-        custom image).
-    *   User or group assignments for IAM permissions.
-*   **Workstation Instances**: Individual workstations instance based on the
-    config, which can be started and used by an assigned developer.
+- **Workstation Cluster**: Provides the management layer and VPC connection
+  for workstation configurations within a specific region.
+- **Workstation Config**: Defines the template for workstations hosted in the
+  cluster. This includes settings like:
+  - Machine type, disk type, and size.
+  - Idle timeout and running timeout.
+  - The container image to use (either a preconfigured Google image or a
+    custom image).
+  - User or group assignments for IAM permissions.
+- **Workstation Instances**: Individual workstations instance based on the
+  config, which can be started and used by an assigned developer.
 
 ## Custom Image Build Process
 
@@ -44,21 +60,21 @@ If custom images are defined via the `cws_custom_images` variable, the module
 will also provision the necessary CI/CD components to build and maintain them
 using either GitHub or Secure Source Manager (SSM) as source:
 
-*   **Secure Source Manager**: If `github_owner` is not provided, a Secure
-    Source Manager instance and repository are provisioned. If the variable
-    `secure_source_manager_repo_git_url_to_clone` is set, a one-time Cloud
-    Build trigger clones the specified Git repository and pushes its content to
-    the SSM repository.
-*   **Cloud Build Trigger**: For each custom image, a trigger is created that
-    builds the container image from source (GitHub or SSM) containing a
-    `skaffold.yaml` and pushes it to Artifact Registry upon changes to the
-    source. If SSM is used, webhooks are automatically configured to trigger
-    builds on push events; the initial clone and push described above will
-    trigger the first build.
-*   **Cloud Scheduler**: For each custom image, a scheduled job is created that
-    periodically triggers Cloud Build to rebuild the image. This is useful for
-    incorporating security patches from base images or updating dependencies,
-    ensuring the workstation image remains up-to-date.
+- **Secure Source Manager**: If `github_owner` is not provided, a Secure
+  Source Manager instance and repository are provisioned. If the variable
+  `secure_source_manager_repo_git_url_to_clone` is set, a one-time Cloud
+  Build trigger clones the specified Git repository and pushes its content to
+  the SSM repository.
+- **Cloud Build Trigger**: For each custom image, a trigger is created that
+  builds the container image from source (GitHub or SSM) containing a
+  `skaffold.yaml` and pushes it to Artifact Registry upon changes to the
+  source. If SSM is used, webhooks are automatically configured to trigger
+  builds on push events; the initial clone and push described above will
+  trigger the first build.
+- **Cloud Scheduler**: For each custom image, a scheduled job is created that
+  periodically triggers Cloud Build to rebuild the image. This is useful for
+  incorporating security patches from base images or updating dependencies,
+  ensuring the workstation image remains up-to-date.
 
 ## Usage
 
@@ -80,13 +96,13 @@ There are two ways to configure this:
 **1. Automated Build and Configuration**
 
 If you want this blueprint to automatically build your custom images from a
-source repository *and* create a corresponding Workstation Config for each
+source repository _and_ create a corresponding Workstation Config for each
 image, you should:
 
-*   Define your images in the `cws_custom_images` map variable, providing
-    details such as the source repository and Dockerfile location.
-*   List the keys of the images you wish to build and deploy in the
-    `custom_image_names` list attribute of your Cloud Workstation Config.
+- Define your images in the `cws_custom_images` map variable, providing
+  details such as the source repository and Dockerfile location.
+- List the keys of the images you wish to build and deploy in the
+  `custom_image_names` list attribute of your Cloud Workstation Config.
 
 For each image key listed in `cws_custom_images`, this blueprint will provision
 a Cloud Build trigger and a Cloud Scheduler job that uses the custom image built

--- a/infra/blueprints/workstations/firewall/cidrs.yaml
+++ b/infra/blueprints/workstations/firewall/cidrs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Google LLC
+# Copyright 2024-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/blueprints/workstations/firewall/rules/ingress-http.yaml
+++ b/infra/blueprints/workstations/firewall/rules/ingress-http.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Google LLC
+# Copyright 2024-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/blueprints/workstations/terraform.tfvars.example
+++ b/infra/blueprints/workstations/terraform.tfvars.example
@@ -253,9 +253,9 @@ android_targets = {
 #       skaffold_path = "apps/devcontainers/node-demo"
 #     }
 #   },
-#   "devcontainer-gvisor-python" : {
+#   "devcontainer-gvisor-antigravity" : {
 #     build = {
-#       skaffold_path = "apps/devcontainers/gvisor-python"
+#       skaffold_path = "apps/devcontainers/gvisor-antigravity"
 #     }
 #   }
 # }

--- a/infra/blueprints/workstations/terraform.tfvars.example
+++ b/infra/blueprints/workstations/terraform.tfvars.example
@@ -84,13 +84,13 @@ project_id = "YOUR_PROJECT_ID"
 
 # Custom images for Cloud Workstations
 cws_custom_images = {
-  "devcontainer-codeoss-node-terraform" : {
+  "codeoss-devcontainer-gvisor-terraform" : {
     git_repo = {
       url    = "https://github.com/GoogleCloudPlatform/cicd-foundation.git"
       branch = "main"
     }
     build = {
-      skaffold_path   = "apps/devcontainers/codeoss-node-terraform"
+      skaffold_path   = "apps/devcontainers/codeoss-devcontainer-gvisor-terraform"
       timeout_seconds = 7200
     }
     workstation_config = {
@@ -164,7 +164,7 @@ cws_configs = {
     custom_image_names             = [
       "antigravity",
       "antigravity2",
-      "devcontainer-codeoss-node-terraform",
+      "codeoss-devcontainer-gvisor-terraform",
     ]
     cws_cluster                    = "workstations"
     #disable_public_ip_addresses    = true  # Defaults to false
@@ -251,6 +251,11 @@ android_targets = {
 #   "devcontainer-node-demo" : {
 #     build = {
 #       skaffold_path = "apps/devcontainers/node-demo"
+#     }
+#   },
+#   "devcontainer-gvisor-python" : {
+#     build = {
+#       skaffold_path = "apps/devcontainers/gvisor-python"
 #     }
 #   }
 # }

--- a/infra/blueprints/workstations/workstations.tf
+++ b/infra/blueprints/workstations/workstations.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "cicd_foundation" {
-  source = "github.com/GoogleCloudPlatform/cicd-foundation//infra/modules/cicd_foundation?ref=v6.0.0"
+  source = "github.com/GoogleCloudPlatform/cicd-foundation//infra/modules/cicd_foundation?ref=v6.0.1"
 
   project_id  = data.google_project.project.project_id
   enable_apis = var.enable_apis

--- a/infra/reference/README.md
+++ b/infra/reference/README.md
@@ -1,6 +1,23 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Reference Architecture
 
 This code reflects a PSO opinionated-view with the following characteristics:
+
 - Enterprise readiness
   - hub & spoke network architecture
 - Resource Management
@@ -17,6 +34,7 @@ For the runtime we make use of a GKE Autopilot cluster per environment.
 ### GCP Organization
 
 The IaC assumes a GCP Organization and a resource management with folders and projects in different environments, i.e.,
+
 - development (DEV)
 - testing (TEST)
 - production (PROD)

--- a/infra/reference/firewall/cidrs.yaml
+++ b/infra/reference/firewall/cidrs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/reference/firewall/rules/ingress-http.yaml
+++ b/infra/reference/firewall/rules/ingress-http.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/simplified/firewall/cidrs.yaml
+++ b/infra/simplified/firewall/cidrs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/simplified/firewall/rules/ingress-http.yaml
+++ b/infra/simplified/firewall/rules/ingress-http.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/skills/persona-sre/scripts/trigger_build.py
+++ b/skills/persona-sre/scripts/trigger_build.py
@@ -24,8 +24,10 @@ and submitting it.
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -130,6 +132,18 @@ def adapt_config(trigger_json: Dict[str, Any]) -> Dict[str, Any]:
     }
 
     return adapted_build
+
+
+def filter_substitutions(substitutions: Dict[str, str], build_config: Dict[str, Any]) -> Dict[str, str]:
+    """Filters substitutions to only include those referenced in the build config."""
+    config_str = json.dumps(build_config)
+    filtered = {}
+    for k, v in substitutions.items():
+        # Match $_VAR or ${_VAR}
+        pattern = rf"\$\{{?{re.escape(k)}\b"
+        if re.search(pattern, config_str):
+            filtered[k] = v
+    return filtered
 
 
 def main():
@@ -264,9 +278,17 @@ def main():
 
     log(f"Submitting build with service account: {service_account}")
 
-    subst_str = ",".join([f"{k}={v}" for k, v in substitutions.items()])
+    filtered_subs = filter_substitutions(substitutions, build_config)
+    removed_subs = set(substitutions.keys()) - set(filtered_subs.keys())
+    if removed_subs:
+        log(f"Filtered out unused substitutions: {', '.join(removed_subs)}")
+    subst_str = ",".join([f"{k}={v}" for k, v in filtered_subs.items()])
 
-    # Submit the build with local source and the adapted config via stdin
+    # Write adapted config to a temp file
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as temp_config:
+        json.dump(build_config, temp_config, indent=2)
+        temp_config_path = temp_config.name
+
     submit_cmd = [
         "gcloud",
         "builds",
@@ -276,15 +298,19 @@ def main():
         f"--region={region}",
         f"--service-account=projects/{project}/serviceAccounts/{service_account}",
         f"--substitutions={subst_str}",
-        "--config=-",
+        f"--config={temp_config_path}",
     ]
 
     try:
-        subprocess.run(
-            submit_cmd, input=json.dumps(build_config), text=True, check=True
-        )
+        log(f"Using temporary config file: {temp_config_path}")
+        subprocess.run(submit_cmd, check=True)
     except subprocess.CalledProcessError as e:
         error(f"build submission failed with exit code {e.returncode}")
+    finally:
+        try:
+            os.unlink(temp_config_path)
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":

--- a/skills/persona-swe/SKILL.md
+++ b/skills/persona-swe/SKILL.md
@@ -2,6 +2,7 @@
 name: persona-swe
 description: Adopts the Software Engineer persona. Focuses on functional correctness, structural integrity, and architectural hygiene, including Source Code Versioning History Refactoring.
 license: Apache-2.0
+allowed-tools: skills/persona-swe/scripts/cmd/link_checker/main.go
 metadata:
   author: sce-taid <sce@taid.me>
   resources:

--- a/skills/persona-swe/scripts/cmd/link_checker/main.go
+++ b/skills/persona-swe/scripts/cmd/link_checker/main.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main implements a markdown link checker tool.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/cicd-foundation/skills/persona-swe/scripts/internal/linkchecker"
+)
+
+// EXCLUDE_DIRS defines directories to skip during scanning.
+var EXCLUDE_DIRS = map[string]bool{
+	".git":         true,
+	".terraform":   true,
+	".venv":        true,
+	"node_modules": true,
+	"build":        true,
+	"dist":         true,
+	"tmp":          true,
+}
+
+func findRepoRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return cwd, nil // Fallback to CWD
+}
+
+func main() {
+	// Support standard -- flag separator
+	flag.Parse()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error finding repo root: %v\n", err)
+		os.Exit(1)
+	}
+
+	var filesToCheck []string
+
+	if len(flag.Args()) > 0 {
+		// Use files passed as arguments
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting CWD: %v\n", err)
+			os.Exit(1)
+		}
+		for _, arg := range flag.Args() {
+			absPath := arg
+			if !filepath.IsAbs(arg) {
+				absPath = filepath.Join(cwd, arg)
+			}
+
+			// Clean the path to resolve relative segments like ..
+			absPath = filepath.Clean(absPath)
+
+			if !strings.HasSuffix(absPath, ".md") {
+				continue
+			}
+			if _, err := os.Stat(absPath); err == nil {
+				filesToCheck = append(filesToCheck, absPath)
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: file not found: %s\n", arg)
+			}
+		}
+		fmt.Printf("Checking %d specified file(s).\n", len(filesToCheck))
+	} else {
+		// Fallback to walking the repository
+		fmt.Printf("Scanning repository root: %s\n", repoRoot)
+		err = filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if EXCLUDE_DIRS[d.Name()] {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(d.Name(), ".md") {
+				filesToCheck = append(filesToCheck, path)
+			}
+			return nil
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error walking directory: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Found %d markdown files to check.\n", len(filesToCheck))
+	}
+
+	if len(filesToCheck) == 0 {
+		fmt.Println("No markdown files to check.")
+		os.Exit(0)
+	}
+
+	// Concurrency setup
+	var wg sync.WaitGroup
+	resultsChan := make(chan linkchecker.FileResult, len(filesToCheck))
+	sem := make(chan struct{}, 50) // Limit concurrency to 50 active files
+
+	for _, path := range filesToCheck {
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			sem <- struct{}{}        // Acquire semaphore
+			defer func() { <-sem }() // Release semaphore
+
+			broken, err := linkchecker.CheckFile(p, repoRoot)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error checking file %s: %v\n", p, err)
+				return
+			}
+			if len(broken) > 0 {
+				resultsChan <- linkchecker.FileResult{
+					FilePath:    p,
+					BrokenLinks: broken,
+				}
+			}
+		}(path)
+	}
+
+	// Close channel when all workers are done
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	totalBroken := 0
+	filesWithBroken := 0
+
+	for result := range resultsChan {
+		filesWithBroken++
+		relPath, err := filepath.Rel(repoRoot, result.FilePath)
+		if err != nil {
+			relPath = result.FilePath
+		}
+		fmt.Printf("\n❌ %s:\n", relPath)
+		for _, bl := range result.BrokenLinks {
+			totalBroken++
+			relResolved, err := filepath.Rel(repoRoot, bl.ResolvedPath)
+			if err != nil {
+				relResolved = bl.ResolvedPath
+			}
+			fmt.Printf("  Line %d: Broken link '%s' (Resolved to: %s)\n", bl.LineNum, bl.Link, relResolved)
+		}
+	}
+
+	fmt.Println("\n======================================")
+	if totalBroken == 0 {
+		fmt.Println(" 🎉 No broken relative links found!")
+		os.Exit(0)
+	} else {
+		fmt.Printf(" ⚠️ Found %d broken link(s) across %d file(s).\n", totalBroken, filesWithBroken)
+		os.Exit(1)
+	}
+}

--- a/skills/persona-swe/scripts/go.mod
+++ b/skills/persona-swe/scripts/go.mod
@@ -1,0 +1,5 @@
+module github.com/GoogleCloudPlatform/cicd-foundation/skills/persona-swe/scripts
+
+go 1.25.9
+
+require github.com/yuin/goldmark v1.8.5 // indirect

--- a/skills/persona-swe/scripts/go.sum
+++ b/skills/persona-swe/scripts/go.sum
@@ -1,0 +1,2 @@
+github.com/yuin/goldmark v1.8.5 h1:r6N5afV5qj/5S4UTch8agZHJ8UxNCMwX7WjkkJam2NA=
+github.com/yuin/goldmark v1.8.5/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/skills/persona-swe/scripts/internal/linkchecker/linkchecker.go
+++ b/skills/persona-swe/scripts/internal/linkchecker/linkchecker.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package linkchecker provides functions to scan markdown files for broken relative links.
+package linkchecker
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// BrokenLink represents a detected broken link.
+type BrokenLink struct {
+	LineNum      int
+	Link         string
+	ResolvedPath string
+}
+
+// FileResult stores the scan results for a single file.
+type FileResult struct {
+	FilePath    string
+	BrokenLinks []BrokenLink
+}
+
+// IsRelativeLink checks if a link is a relative file path.
+func IsRelativeLink(link string) bool {
+	if link == "" {
+		return false
+	}
+	// Ignore web links, mailto, anchors, and protocols
+	if strings.HasPrefix(link, "http://") ||
+		strings.HasPrefix(link, "https://") ||
+		strings.HasPrefix(link, "mailto:") ||
+		strings.HasPrefix(link, "tel:") ||
+		strings.HasPrefix(link, "#") ||
+		strings.HasPrefix(link, "chrome-extension://") ||
+		strings.HasPrefix(link, "file://") {
+		return false
+	}
+	return true
+}
+
+// CleanLink removes anchor queries or parameters from the link.
+func CleanLink(link string) string {
+	// Remove anchor
+	if idx := strings.Index(link, "#"); idx != -1 {
+		link = link[:idx]
+	}
+	// Remove query params
+	if idx := strings.Index(link, "?"); idx != -1 {
+		link = link[:idx]
+	}
+	return strings.TrimSpace(link)
+}
+
+// CheckFile parses the markdown file, extracts relative links, and verifies their existence.
+func CheckFile(path string, repoRoot string) ([]BrokenLink, error) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	md := goldmark.New()
+	doc := md.Parser().Parse(text.NewReader(source))
+
+	var brokenLinks []BrokenLink
+	fileDir := filepath.Dir(path)
+
+	err = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		var dest []byte
+		switch n := node.(type) {
+		case *ast.Link:
+			dest = n.Destination
+		case *ast.Image:
+			dest = n.Destination
+		}
+
+		if len(dest) == 0 {
+			return ast.WalkContinue, nil
+		}
+
+		rawLink := string(dest)
+		if !IsRelativeLink(rawLink) {
+			return ast.WalkContinue, nil
+		}
+
+		link := CleanLink(rawLink)
+		if link == "" {
+			return ast.WalkContinue, nil
+		}
+
+		var resolvedPath string
+		if strings.HasPrefix(link, "/") {
+			resolvedPath = filepath.Join(repoRoot, link)
+		} else {
+			resolvedPath = filepath.Join(fileDir, link)
+		}
+
+		// Check if exists
+		if _, err := os.Stat(resolvedPath); os.IsNotExist(err) {
+			lineNum := 1
+			offset := node.Pos()
+
+			if offset >= 0 && offset < len(source) {
+				lineNum = bytes.Count(source[:offset], []byte("\n")) + 1
+			}
+
+			brokenLinks = append(brokenLinks, BrokenLink{
+				LineNum:      lineNum,
+				Link:         rawLink,
+				ResolvedPath: resolvedPath,
+			})
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk AST: %w", err)
+	}
+
+	return brokenLinks, nil
+}
+
+

--- a/skills/persona-swe/scripts/internal/linkchecker/linkchecker_test.go
+++ b/skills/persona-swe/scripts/internal/linkchecker/linkchecker_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linkchecker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsRelativeLink(t *testing.T) {
+	tests := []struct {
+		link string
+		want bool
+	}{
+		{"", false},
+		{"http://example.com", false},
+		{"https://example.com/foo", false},
+		{"mailto:test@example.com", false},
+		{"tel:123456", false},
+		{"#anchor", false},
+		{"chrome-extension://foo", false},
+		{"file:///path/to/file", false},
+		{"./foo.md", true},
+		{"../bar.md", true},
+		{"foo/bar.md", true},
+		{"/foo/bar.md", true},
+		{"foo.md#section", true},
+		{"foo.md?param=value", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.link, func(t *testing.T) {
+			t.Helper()
+			if got := IsRelativeLink(tt.link); got != tt.want {
+				t.Errorf("IsRelativeLink(%q) = %v, want %v", tt.link, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanLink(t *testing.T) {
+	tests := []struct {
+		link string
+		want string
+	}{
+		{"foo.md", "foo.md"},
+		{"foo.md#section", "foo.md"},
+		{"foo.md?param=value", "foo.md"},
+		{"foo.md?param=value#section", "foo.md"},
+		{"  foo.md  ", "foo.md"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.link, func(t *testing.T) {
+			t.Helper()
+			if got := CleanLink(tt.link); got != tt.want {
+				t.Errorf("CleanLink(%q) = %q, want %q", tt.link, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckFile(t *testing.T) {
+	// Create a temp directory for tests
+	tmpDir, err := os.MkdirTemp("", "linkchecker_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create some dummy target files
+	validFile := filepath.Join(tmpDir, "valid.md")
+	if err := os.WriteFile(validFile, []byte("valid"), 0644); err != nil {
+		t.Fatalf("Failed to create valid.md: %v", err)
+	}
+
+	// Create a markdown file to check
+	checkContent := `
+# Test Markdown
+
+This is a [valid link](./valid.md).
+This is a [broken link](./broken.md).
+This is an [external link](https://google.com).
+
+Here is a link in a code block that should be ignored:
+` + "`[ignored link](./broken.md)`" + `
+
+Here is a multi-line code block to ignore:
+` + "```markdown" + `
+[ignored block link](./broken.md)
+` + "```" + `
+
+Here is an HTML comment that should be ignored:
+<!-- [ignored comment link](./broken.md) -->
+
+This is a [valid root relative link](/valid.md) if repo root is set to tmpDir.
+This is a [broken root relative link](/broken.md).
+`
+
+	testFile := filepath.Join(tmpDir, "test.md")
+	if err := os.WriteFile(testFile, []byte(checkContent), 0644); err != nil {
+		t.Fatalf("Failed to create test.md: %v", err)
+	}
+
+	// Run CheckFile
+	broken, err := CheckFile(testFile, tmpDir)
+	if err != nil {
+		t.Fatalf("CheckFile failed: %v", err)
+	}
+
+	// We expect 2 broken links:
+	// 1. [broken link](./broken.md) (line 5)
+	// 2. [broken root relative link](/broken.md) (line 20)
+	expected := []struct {
+		link    string
+		lineNum int
+	}{
+		{"./broken.md", 5},
+		{"/broken.md", 20},
+	}
+
+	if len(broken) != len(expected) {
+		t.Fatalf("Expected %d broken links, got %d: %v", len(expected), len(broken), broken)
+	}
+
+	for i, ext := range expected {
+		got := broken[i]
+		if got.Link != ext.link {
+			t.Errorf("Link[%d]: expected %q, got %q", i, ext.link, got.Link)
+		}
+		if got.LineNum != ext.lineNum {
+			t.Errorf("LineNum[%d] (link %s): expected %d, got %d", i, ext.link, ext.lineNum, got.LineNum)
+		}
+	}
+}
+
+func TestCheckFile_Error(t *testing.T) {
+	_, err := CheckFile("non_existent_file.md", "")
+	if err == nil {
+		t.Error("Expected error when checking non-existent file, got nil")
+	}
+}


### PR DESCRIPTION
- Install gVisor (`runsc`) during image build and configure the pre-installed Docker-in-Docker daemon to use it as a runtime.
- Add new `gvisor-antigravity` devcontainer application configured to run with gVisor (`runsc`) runtime and pre-installed Antigravity 
CLI and SDK.
